### PR TITLE
UHM-6355, do not overwrite the location selected by the user

### DIFF
--- a/omod/src/main/webapp/resources/scripts/components/LabTrackingOrderFactory.js
+++ b/omod/src/main/webapp/resources/scripts/components/LabTrackingOrderFactory.js
@@ -160,7 +160,9 @@ angular.module("labTrackingOrderFactory", [])
             labTrackingOrder.careSetting.value = webServiceResult.careSetting.uuid;
             labTrackingOrder.careSetting.label = webServiceResult.careSetting.display;
           }
-          labTrackingOrder.locationWhereSpecimenCollected = labTrackingOrder.location;
+          if ( !labTrackingOrder.locationWhereSpecimenCollected.value) {
+            labTrackingOrder.locationWhereSpecimenCollected= labTrackingOrder.location;
+          }
           return labTrackingOrder;
         }
 


### PR DESCRIPTION
Thanks @mogoodrich for uncovering this problem with the encounter location. It was always set to the encounter location and it was ignoring the location selected in the specimen collection form.