### PR TITLE
UHM-6378, refactor the pathology orders search

### DIFF
--- a/api/src/main/java/org/openmrs/module/labtrackingapp/api/LabTrackingAppService.java
+++ b/api/src/main/java/org/openmrs/module/labtrackingapp/api/LabTrackingAppService.java
@@ -33,13 +33,28 @@ public interface LabTrackingAppService extends OpenmrsService {
 	 * @suspectedCancer - (optional) indicating if the sample is suspected for cancer
 	 * @urgentReview - (optional) indicating if the sample needs urgent review
 	 * @param maxResults - (optional) the max results to show, if 0 then all
-	 */	public List<Order> getActiveOrders(long startDate, long endDate, String patientUuid, String patientName, int status, boolean suspectedCancer, boolean urgentReview, int maxResults);
+	 */
+	public List<Order> getActiveOrders(long startDate, long endDate, String patientUuid, String patientName, int status, boolean suspectedCancer, boolean urgentReview, int maxResults);
 
 	/* gets the specimen details encounter associated with the Test order
 	* @param orderNumber - an array of order numbers to look up
 	* the Encounter
 	* */
 	public List<Encounter> getSpecimenDetailsEncountersByOrderNumbers(String[] orderNumbers);
+
+	/**
+	 * gets all the Pathology orders within a given timeframe
+	 * @param startDate
+	 * @param endDate
+	 * @param patientUuid
+	 * @param patientName
+	 * @param status
+	 * @param suspectedCancer
+	 * @param urgentReview
+	 * @param maxResults
+	 * @return
+	 */
+	public List<Encounter> getSpecimenDetailsEncountersByDate(long startDate, long endDate, String patientUuid, String patientName, int status, boolean suspectedCancer, boolean urgentReview, int maxResults);
 
      /*
 	 * gets a summary of the active orders for a patient

--- a/api/src/main/java/org/openmrs/module/labtrackingapp/api/db/LabTrackingAppDAO.java
+++ b/api/src/main/java/org/openmrs/module/labtrackingapp/api/db/LabTrackingAppDAO.java
@@ -15,6 +15,8 @@ package org.openmrs.module.labtrackingapp.api.db;
 
 import org.openmrs.Encounter;
 import org.openmrs.Order;
+import org.openmrs.OrderType;
+
 import java.util.List;
 
 /**
@@ -40,5 +42,18 @@ public interface LabTrackingAppDAO {
 	* @return the list of Encounters if there is one, otherwise null
 	* */
 	public List<Encounter> getSpecimenDetailsEncountersByOrderNumbers(String[] orderNumbers);
+
+	/**
+	 * gets all Orders within a timeframe
+	 * @param startDate
+	 * @param endDate
+	 * @param patientUuid
+	 * @param patientName
+	 * @param status
+	 * @param orderTypes
+	 * @param maxResults
+	 * @return
+	 */
+	public List<Order> getOrdersByDate(long startDate, long endDate, String patientUuid, String patientName, int status, List<OrderType> orderTypes, int maxResults);
 
 }

--- a/api/src/test/java/org/openmrs/module/labtrackingapp/api/LabTrackingAppServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/labtrackingapp/api/LabTrackingAppServiceTest.java
@@ -49,6 +49,7 @@ public class LabTrackingAppServiceTest extends BaseModuleContextSensitiveTest {
 	private OrderService orderService;
 
 	private static final int TOTAL_ACTIVE_ORDERS = 4;
+	private static final int TOTAL_ACTIVE_ENCOUNTER_ORDERS = 3;
 	private static final int TOTAL_SAMPLED_ORDERS = 1;
 	private static final int TOTAL_REQUESTED_ORDERS = 2;
 	private static final int TOTAL_RESULTS_ORDERS = 1;
@@ -82,6 +83,36 @@ public class LabTrackingAppServiceTest extends BaseModuleContextSensitiveTest {
 		int status = LabTrackingConstants.LabTrackingOrderStatus.ALL.getId();
 		List<Order> list = service.getActiveOrders(startDate, endDate, patientUuid, patientName, status, false, false, 0);
 		assertEquals(TOTAL_ACTIVE_ORDERS, list.size());
+	}
+
+	@Test
+	@Verifies(value =  "should get ALL specimen collection encounters", method = "getSpecimenDetailsEncountersByDate")
+	public void getSpecimenDetailsEncountersByDate_shouldGetByDate() throws Exception {
+		Date testDate = getTestEncounterDate();
+		long startDate = testDate.getTime()-1000*60*60;
+		long endDate = testDate.getTime()+1000*60*60;
+		String patientUuid = null;
+		String patientName = null;
+		int status = LabTrackingConstants.LabTrackingOrderStatus.ALL.getId();
+
+		List<Encounter> specimenDetailsEncountersByDate = service.getSpecimenDetailsEncountersByDate(startDate, endDate, patientUuid, patientName, status, false, false, 0);
+		assertEquals(TOTAL_ACTIVE_ENCOUNTER_ORDERS, specimenDetailsEncountersByDate.size());
+
+	}
+
+	@Test
+	@Verifies(value =  "should get specimen collection encounters by name", method = "getSpecimenDetailsEncountersByDate")
+	public void getSpecimenDetailsEncountersByDate_shouldGetByName() throws Exception {
+		Date testDate = getTestEncounterDate();
+		long startDate = testDate.getTime()-1000*60*60;
+		long endDate = testDate.getTime()+1000*60*60;
+		String patientUuid = null;
+		String patientName = null;
+		int status = LabTrackingConstants.LabTrackingOrderStatus.ALL.getId();
+
+		List<Encounter> specimenDetailsEncountersByDate = service.getSpecimenDetailsEncountersByDate(startDate, endDate, patientUuid, "Hamil", status, false, false, 0);
+		assertEquals(TOTAL_ACTIVE_ENCOUNTER_ORDERS, specimenDetailsEncountersByDate.size());
+
 	}
 
 	@Test

--- a/omod/src/main/java/org/openmrs/module/labtrackingapp/rest/web/v1_0/search/openmrs1_10/EncounterSearchHandler1_10.java
+++ b/omod/src/main/java/org/openmrs/module/labtrackingapp/rest/web/v1_0/search/openmrs1_10/EncounterSearchHandler1_10.java
@@ -20,9 +20,16 @@ import java.util.List;
 public class EncounterSearchHandler1_10 implements SearchHandler {
 	
 	private static final String REQUEST_PARAM_ORDER_NUMBER = "orderNumbers";
+	private static final String REQUEST_PARAM_START_DATE = "startDateInMillis";
+	private static final String REQUEST_PARAM_END_DATE = "endDateInMillis";
+	private static final String REQUEST_PARAM_STATUS = "status";
+	private static final String REQUEST_PARAM_SUSPECTED_CANCER = "suspectedCancer";
+	private static final String REQUEST_PARAM_URGENT_REVIEW = "urgentReview";
+	private static final String REQUEST_PARAM_PATIENT = "patient";
+	private static final String REQUEST_PARAM_PATIENT_NAME = "name";
+	private static final String REQUEST_PARAM_TOTAL_COUNT = "totalCount";
 	
-	private final SearchQuery searchQuery = new SearchQuery.Builder("Gets the specimen details associated with an encounter")
-	        .withRequiredParameters(REQUEST_PARAM_ORDER_NUMBER).build();
+	private final SearchQuery searchQuery = new SearchQuery.Builder("Gets the specimen details associated with an encounter").withOptionalParameters(REQUEST_PARAM_ORDER_NUMBER, REQUEST_PARAM_PATIENT, REQUEST_PARAM_PATIENT_NAME, REQUEST_PARAM_START_DATE,REQUEST_PARAM_END_DATE,REQUEST_PARAM_STATUS, REQUEST_PARAM_SUSPECTED_CANCER, REQUEST_PARAM_URGENT_REVIEW, REQUEST_PARAM_TOTAL_COUNT).build();
 	
 	private final SearchConfig searchConfig = new SearchConfig("getSpecimenDetailsEncounter", RestConstants.VERSION_1 + "/encounter",
 	        Arrays.asList("1.10.*", "1.11.*", "1.12.*", "2.*"), searchQuery);
@@ -40,16 +47,74 @@ public class EncounterSearchHandler1_10 implements SearchHandler {
 	 */
 	//@Override
 	public PageableResult search(RequestContext context) throws ResponseException {
-		String temp = context.getParameter(REQUEST_PARAM_ORDER_NUMBER);
+		String orderNumberParam = context.getParameter(REQUEST_PARAM_ORDER_NUMBER);
+		String patientUuid = context.getParameter(REQUEST_PARAM_PATIENT);
+		String patientName = context.getParameter(REQUEST_PARAM_PATIENT_NAME);
+		int status = toInt(context.getParameter(REQUEST_PARAM_STATUS), 0);
+		boolean suspectedCancer = toBoolean(context.getParameter(REQUEST_PARAM_SUSPECTED_CANCER), false);
+		boolean urgentReview = toBoolean(context.getParameter(REQUEST_PARAM_URGENT_REVIEW), false);
+		long startDate = toLong(context.getParameter(REQUEST_PARAM_START_DATE), 0);
+		long endDate = toLong(context.getParameter(REQUEST_PARAM_END_DATE), 0);
+
+
 		List<Encounter> ret = null;
-		if(temp != null){
-			String[] orderNumbers = temp.split(",");
+		if(orderNumberParam != null){
+			String[] orderNumbers = orderNumberParam.split(",");
 			ret = Context.getService(LabTrackingAppService.class).getSpecimenDetailsEncountersByOrderNumbers(orderNumbers);
+		} else if ( startDate > 0 && endDate > 0) {
+			ret = Context.getService(LabTrackingAppService.class).getSpecimenDetailsEncountersByDate(
+					startDate,
+					endDate,
+					patientUuid,
+					patientName,
+					status,
+					suspectedCancer,
+					urgentReview,
+					0);
 		}
 
 
 		//TODO:  how do you just return one in search, for now wrap in a list
 		return new NeedsPaging<Encounter>(ret, context);
+	}
+
+	public int toInt(String v, int defaultVal){
+		int ret = defaultVal;
+		if(v == null){
+			return ret;
+		}
+		try{
+			ret = Integer.parseInt(v);
+		}   catch(Exception e){
+			//return default
+		}
+		return ret;
+	}
+
+	public long toLong(String v, long defaultVal){
+		long ret = defaultVal;
+		if(v == null){
+			return ret;
+		}
+		try{
+			ret = Long.parseLong(v);
+		}   catch(Exception e){
+			//return default
+		}
+		return ret;
+	}
+
+	public boolean toBoolean(String v, boolean defaultVal){
+		boolean ret = defaultVal;
+		if(v == null){
+			return ret;
+		}
+		try{
+			ret = Boolean.parseBoolean(v);
+		}   catch(Exception e){
+			//return default
+		}
+		return ret;
 	}
 	
 }

--- a/omod/src/main/webapp/resources/scripts/components/LabTrackingViewQueueController.js
+++ b/omod/src/main/webapp/resources/scripts/components/LabTrackingViewQueueController.js
@@ -101,16 +101,15 @@ angular.module("labTrackingViewQueueController", [])
                 var urgentReview = $scope.filter.urgentReview;
                 var patientName = $scope.filter.patient.name;
 
-                return LabTrackingDataService.loadQueue(pageNumber, startDate, endDate, status, $scope.patientUuid, patientName, suspectedCancer, urgentReview).then(function (resp) {
+                return LabTrackingDataService.loadPathologyQueue(pageNumber, startDate, endDate, status, $scope.patientUuid, patientName, suspectedCancer, urgentReview).then(function (resp) {
                     if (resp.status.code == 200) {
                         var cnt = resp.data.totalCount;
-                        return LabTrackingDataService.loadSpecimenDetailsForQueue(resp.data.orders).then(function (resp2) {
-                            $scope.testOrderQueue = resp2.data;
-                            $scope.setPage(pageNumber, cnt);
-                            $scope.data_loading = false;
-                            //update your cookies
-                            $cookies.putObject($scope.cookieForFilter, $scope.filter);
-                        })
+                        $scope.testOrderQueue = resp.data.orders;
+                        $scope.setPage(pageNumber, cnt);
+                        $scope.data_loading = false;
+                        //update your cookies
+                        $cookies.putObject($scope.cookieForFilter, $scope.filter);
+
                     }
                     else {
                         $scope.errorMessage = resp.status.msg;


### PR DESCRIPTION
Since now the pathology order is now direct attached to the Pathology Specimen Collection encounter, there is no need anymore to retrieve the orders independently of the encounters. I am sure this code could be refactored a bit more but I was eager to get it working and test the performance of this new query. On my dev machine with a production like db the previous pathology tracking table was loading in 25 seconds, now it takes half o second to load the page and the searching is very fast as well. Thanks @mogoodrich for reviewing it! 