### PR TITLE
UHM-3744, create pathology encounter when the client is in a different timezone

### DIFF
--- a/omod/src/main/java/org/openmrs/module/labtrackingapp/page/controller/LabtrackingAddOrderPageController.java
+++ b/omod/src/main/java/org/openmrs/module/labtrackingapp/page/controller/LabtrackingAddOrderPageController.java
@@ -8,6 +8,10 @@ import org.openmrs.module.appui.UiSessionContext;
 import org.openmrs.ui.framework.page.PageModel;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.TimeZone;
+
 public class LabtrackingAddOrderPageController {
 
     public Object controller(PageModel model, @RequestParam(value = "appId", required = false) AppDescriptor app,
@@ -23,6 +27,21 @@ public class LabtrackingAddOrderPageController {
         model.addAttribute("location", uiSessionContext.getSessionLocation());
         model.addAttribute("patient", patient);
         model.addAttribute("visit", visit);
+        String zonedVisitStartDateTime = null;
+        String zonedVisitEndDateTime = null;
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+        sdf.setTimeZone(TimeZone.getDefault());
+        Calendar calendar = Calendar.getInstance();
+        if (visit != null && visit.getStartDatetime() != null) {
+            calendar.setTime(visit.getStartDatetime());
+            zonedVisitStartDateTime = sdf.format(calendar.getTime());
+            if (visit.getStopDatetime() != null) {
+                calendar.setTime(visit.getStopDatetime());
+                zonedVisitEndDateTime = sdf.format(calendar.getTime());
+            }
+        }
+        model.addAttribute("visitStartDateTime", zonedVisitStartDateTime);
+        model.addAttribute("visitEndDateTime", zonedVisitEndDateTime);
         model.addAttribute("orderUuid", orderUuid);
         model.addAttribute("serverDatetime", new DateTime()); // just in case the server and client time are not in sync
 

--- a/omod/src/main/webapp/pages/labtrackingAddOrder.gsp
+++ b/omod/src/main/webapp/pages/labtrackingAddOrder.gsp
@@ -255,8 +255,8 @@ ${ ui.includeFragment("coreapps", "patientHeader", [ patient: patient ]) }
       .value('patientUuid', '${ patient.uuid }')
       .value('visitUuid', '${ visit.uuid }')
       .value('orderUuid', '${ orderUuid }')
-      .value('visitStartDateTime', '${ visit ? visit.startDatetime : '' }')
-      .value('visitStopDateTime', '${ visit && visit.stopDatetime ? visit.stopDatetime : '' }')
+      .value('visitStartDateTime', '${ visit ? visitStartDateTime : '' }')
+      .value('visitStopDateTime', '${ visit && visit.stopDatetime ? visitEndDateTime : '' }')
       .value('serverDatetime', '${ serverDatetime }')
       .value('locationUuid', '${ location.uuid }');
 

--- a/omod/src/main/webapp/pages/labtrackingViewQueue.gsp
+++ b/omod/src/main/webapp/pages/labtrackingViewQueue.gsp
@@ -106,7 +106,10 @@ ${patient?ui.includeFragment("coreapps", "patientHeader", [ patient: patient ]) 
                         </a>
                      </td>
                      <td class="text-center small">
-                        <a role="button" ng-class="{ 'no-link': !canEdit() }" ng-click="canEdit() && handleDetails(a, 'specimen')"><span title="Enter a value" ng-if="canEdit() && a.processedDate.value==null"><i class="glyphicon glyphicon-edit" aria-hidden="true"></i> ${ui.message("labtrackingapp.listpage.enter")}</span><span ng-if="a.processedDate.value!=null">{{a.processedDate.value | date : dateFormat }}</span></a>
+                        <a role="button" ng-class="{ 'no-link': !canEdit() }" ng-click="canEdit() && handleDetails(a, 'specimen')">
+                           <span title="Enter a value" ng-if="canEdit() && a.processedDate.value==null">
+                              <i class="glyphicon glyphicon-edit" aria-hidden="true"></i> ${ui.message("labtrackingapp.listpage.enter")}</span>
+                           <span ng-if="a.processedDate.value!=null">{{a.processedDate.value | date : dateFormat }}</span></a>
                      </td>
                      <td class="text-center small"><span role="button" ng-show="a.file.url!=null" ng-click="downloadPdf(a)" title="Download"><i class="glyphicon glyphicon-download" aria-hidden="true"></i></span>
                          <a role="button" ng-class="{ 'no-link': !canEdit() }" ng-click="canEdit() && handleDetails(a, 'results')">

--- a/omod/src/main/webapp/resources/scripts/components/LabTrackingAddOrderController.js
+++ b/omod/src/main/webapp/resources/scripts/components/LabTrackingAddOrderController.js
@@ -13,18 +13,18 @@ angular.module("labTrackingAddOrderController", [])
             $scope.providers = []; // the proviers in the system
             $scope.concepts = LabTrackingOrder.concepts;
 
-            $scope.serverDatetime = new Date($filter('serverDate')(serverDatetime));  // we use the current Date from the server, not the client, to avoid problems if times aren't in sync
-            $scope.visitStartDateTime = new Date( $filter('serverDate')(visitStartDateTime));
+            $scope.clientDatetime = new Date();
+            $scope.visitStartDateTime = new Date( visitStartDateTime);
             if (visitStopDateTime) {
-                $scope.visitStopDateTime = new Date( $filter('serverDate')(visitStopDateTime));
+                $scope.visitStopDateTime = new Date(visitStopDateTime);
             }
 
             // if a single day visit, just set the model value to that date
             if (sameDate($scope.visitStartDateTime, $scope.visitStopDateTime)) {
-                $scope.order.sampleDate.value = $scope.visitStartDateTime;
+                $scope.order.sampleDate.value = visitStartDateTime;
             } // if not a single day visit, but an active visit, set request date to current date
             else if (!visitStopDateTime) {
-                $scope.order.sampleDate.value = $scope.serverDatetime;
+                $scope.order.sampleDate.value = $scope.clientDatetime;
             }
 
             $scope.loadOrder = function (orderUuid) {
@@ -35,7 +35,7 @@ angular.module("labTrackingAddOrderController", [])
                   $scope.order = resp.data;
                   if($scope.order.sampleDate.value == null){
                     //if we don't have a sample date, then set a default value
-                    $scope.order.sampleDate.value =  $scope.serverDatetime;
+                    $scope.order.sampleDate.value =  $scope.clientDatetime;
                   }
                 }
                 else {
@@ -53,7 +53,7 @@ angular.module("labTrackingAddOrderController", [])
                     formatYear: 'yy',
                     minDate:  $scope.visitStartDateTime,
                     initDate:  $scope.visitStartDateTime,
-                    maxDate: $scope.visitStopDateTime ? $scope.visitStopDateTime : $scope.serverDatetime,
+                    maxDate: $scope.visitStopDateTime ? $scope.visitStopDateTime : $scope.clientDatetime,
                     showWeeks: false
                 },
                 altInputFormats: ['M!/d!/yyyy']
@@ -68,12 +68,12 @@ angular.module("labTrackingAddOrderController", [])
             $scope.handleSaveOrder = function () {
                 $scope.savingModal = showSavingModal();
                 // keep the Order Request datetime within the boundaries of the visit
-                if ( $scope.order.sampleDate.value < $scope.visitStartDateTime ) {
-                    $scope.order.sampleDate.value = $scope.visitStartDateTime;
-                }
-                else if ( $scope.visitStopDateTime && $scope.order.sampleDate.value > $scope.visitStopDateTime ) {
-                    $scope.order.sampleDate.value = $scope.visitStopDateTime;
-                }
+                // if ( $scope.order.sampleDate.value < $scope.visitStartDateTime ) {
+                //     $scope.order.sampleDate.value = $scope.visitStartDateTime;
+                // }
+                // else if ( $scope.visitStopDateTime && $scope.order.sampleDate.value > $scope.visitStopDateTime ) {
+                //     $scope.order.sampleDate.value = $scope.visitStopDateTime;
+                // }
 
                 return LabTrackingDataService.saveOrder($scope.order).then(function (res) {
                     if (LabTrackingDataService.isOk(res)) {

--- a/omod/src/main/webapp/resources/scripts/components/LabTrackingOrderDetailsController.js
+++ b/omod/src/main/webapp/resources/scripts/components/LabTrackingOrderDetailsController.js
@@ -17,7 +17,7 @@ angular.module("labTrackingOrderDetailsController", [])
             $scope.providers = []; // the proviers in the system
             $scope.locations = []; //the locations in the system
 
-            $scope.serverDatetime = new Date($filter('serverDate')(serverDatetime));  // we use the current Date from the server, not the client, to avoid problems if times aren't in sync
+            $scope.clientDatetime = new Date();
 
             /*
              loads the queue from the openmrs web services
@@ -28,10 +28,10 @@ angular.module("labTrackingOrderDetailsController", [])
                 return LabTrackingDataService.loadOrder(orderUuid).then(function (resp) {
                     if (resp.status.code == 200) {
                         $scope.order = resp.data;
-                        $scope.order.serverDatetime = $scope.serverDatetime;
+                        $scope.order.serverDatetime = $scope.clientDatetime;
                         if($scope.order.sampleDate.value == null){
                             //if we don't have a sample date, then set a default value
-                            $scope.order.sampleDate.value =  $scope.serverDatetime;
+                            $scope.order.sampleDate.value =  $scope.clientDatetime;
                         }
                     }
                     else {

--- a/omod/src/main/webapp/resources/scripts/components/LabTrackingOrderFactory.js
+++ b/omod/src/main/webapp/resources/scripts/components/LabTrackingOrderFactory.js
@@ -177,7 +177,7 @@ angular.module("labTrackingOrderFactory", [])
       LabTrackingOrder.fromEncounterRestObject = function (webServiceResult) {
         var order = new LabTrackingOrder();
 
-        order.sampleDate.value = new Date($filter('serverDate')(webServiceResult.encounterDatetime));
+        order.sampleDate.value = new Date(webServiceResult.encounterDatetime);
         order.specimenDetailsEncounter.uuid = webServiceResult.uuid;
 
         order.encounter.value = webServiceResult.uuid;
@@ -306,15 +306,15 @@ angular.module("labTrackingOrderFactory", [])
                 }
               }
               else if (conceptUuid == LabTrackingOrder.concepts.resultDate.value) {
-                order.resultDate.value = new Date($filter('serverDate')(obs[i].valueDatetime));
+                order.resultDate.value = new Date(obs[i].valueDatetime);
                 order.resultDate.obsUuid = uuid;
               }
               else if (conceptUuid == LabTrackingOrder.concepts.processedDate.value) {
-                order.processedDate.value = new Date($filter('serverDate')(obs[i].valueDatetime));
+                order.processedDate.value = new Date(obs[i].valueDatetime);
                 order.processedDate.obsUuid = uuid;
               }
               else if (conceptUuid == LabTrackingOrder.concepts.dateImmunoSentToBoston.value) {
-                order.dateImmunoSentToBoston.value = new Date($filter('serverDate')(obs[i].valueDatetime));
+                order.dateImmunoSentToBoston.value = new Date(obs[i].valueDatetime);
                 order.dateImmunoSentToBoston.obsUuid = uuid;
               }
               else if (conceptUuid == LabTrackingOrder.concepts.file.value) {
@@ -431,7 +431,7 @@ angular.module("labTrackingOrderFactory", [])
             order.patient.value = webServiceResult.patient.person.uuid;
             order.patient.name = webServiceResult.patient.person.display;
             order.patient.id = webServiceResult.patient.identifiers[0].identifier;
-            order.sampleDate.value = new Date($filter('serverDate')(webServiceResult.dateActivated));
+            order.sampleDate.value = new Date(webServiceResult.dateActivated);
 
             if (webServiceResult.auditInfo != null && webServiceResult.auditInfo.voidedBy != null) {
                 order.canceled = true;
@@ -473,7 +473,7 @@ angular.module("labTrackingOrderFactory", [])
             labTrackingOrder.postopDiagnosis.diagnosis = {label: null, value: null};
 
             // now start setting values based on encounter
-            labTrackingOrder.sampleDate.value = new Date($filter('serverDate')(webServiceResult.encounterDatetime));
+            labTrackingOrder.sampleDate.value = new Date(webServiceResult.encounterDatetime);
             labTrackingOrder.specimenDetailsEncounter.uuid = webServiceResult.uuid;
 
             if (webServiceResult.location != null) {
@@ -552,15 +552,15 @@ angular.module("labTrackingOrderFactory", [])
                             }
                         }
                         else if (conceptUuid == LabTrackingOrder.concepts.resultDate.value) {
-                            labTrackingOrder.resultDate.value = new Date($filter('serverDate')(v));
+                            labTrackingOrder.resultDate.value = new Date(v);
                             labTrackingOrder.resultDate.obsUuid = uuid;
                         }
                        else if (conceptUuid == LabTrackingOrder.concepts.processedDate.value) {
-                            labTrackingOrder.processedDate.value = new Date($filter('serverDate')(v));
+                            labTrackingOrder.processedDate.value = new Date(v);
                             labTrackingOrder.processedDate.obsUuid = uuid;
                         }
                         else if (conceptUuid == LabTrackingOrder.concepts.dateImmunoSentToBoston.value) {
-                          labTrackingOrder.dateImmunoSentToBoston.value = new Date($filter('serverDate')(v));
+                          labTrackingOrder.dateImmunoSentToBoston.value = new Date(v);
                           labTrackingOrder.dateImmunoSentToBoston.obsUuid = uuid;
                         }
                         else if (conceptUuid == LabTrackingOrder.concepts.file.value) {


### PR DESCRIPTION
There were two main problems:

1. serverDatetine is not needed. the client and the server are able to handle datetimes in different timezone as long as the timezone information is included in the datetime string exchanged. The following line of code was not needed:
    $scope.serverDatetime = new Date($filter('serverDate')(serverDatetime)); 
3. the visitStartDatetime gsp variable did not include the timezone component, therefore the following line of code:
$scope.visitStartDateTime = new Date( $filter('serverDate')(visitStartDateTime));
was taking the server time but it added the client timezone, therefore when the encounterDatetime was posted back to the server was 3 hours ahead of the server time. 

@mogoodrich , I am happy to explain more if the above and the code changes below need more explanation.
I have tested this with client 3 hours behind the server, and with the client 4 hours ahead of the server time, and i was able to successfully create encounters and obs 