### PR TITLE
HAI-1184: filter procedure's locations to the locations associated with user's login visit location

### DIFF
--- a/omod/src/main/webapp/resources/scripts/components/LabTrackingAddOrderController.js
+++ b/omod/src/main/webapp/resources/scripts/components/LabTrackingAddOrderController.js
@@ -10,6 +10,8 @@ angular.module("labTrackingAddOrderController", [])
             $scope.error = null; // when not null, this message will show on the screen
             $scope.debugInfo = null;  // for debugging
             $scope.locations = []; // clinical locations in the system
+            $scope.allEmrLocations = [];
+            $scope.visitLocations = [];
             $scope.providers = []; // the proviers in the system
             $scope.concepts = LabTrackingOrder.concepts;
 
@@ -240,14 +242,60 @@ angular.module("labTrackingAddOrderController", [])
             }
 
             /*
+             * Loads locations for the current session location.
+             *
+             * This function filters all EMR locations to find those that:
+             * 1. Belong to the same visit location as the current session location
+             * 2. Are tagged with the "Consult Note" location tag
+             *
+             * The filtered locations are added to $scope.locations for use in the UI.
+             *
+             * Process:
+             * - Find the location matching the current session location UUID
+             * - Get its associated visit location
+             * - Search all locations that share the same visit location
+             * - Filter to only include those with the LOCATION_CONSULT_NOTE_UUID tag
+             * - Add matching locations to $scope.locations array
+             */
+            function loadLocationsForSession() {
+                if ($scope.allEmrLocations.length > 0) {
+                    var sessionLocation = LabTrackingDataService.getSessionLocation();
+                    if (sessionLocation) {
+                        // Find the location object that matches the current session location
+                        var matchingLocation = $scope.allEmrLocations.find(function (loc) {
+                            return loc.uuid === sessionLocation.uuid;
+                        });
+                        if (matchingLocation && matchingLocation.visitLocation && matchingLocation.visitLocation.uuid) {
+                            // Iterate through all locations to find those in the same visit location
+                            for (var i = 0; i < $scope.allEmrLocations.length; i++) {
+                                var item = $scope.allEmrLocations[i];
+                                // Check if this location belongs to the same visit location
+                                if (item.visitLocation && item.visitLocation.uuid === matchingLocation.visitLocation.uuid) {
+                                    // Check if this location has the required "Consult Note" tag
+                                    var consultNoteTag = item.tags.find(function (tag) {
+                                        return tag.uuid === LabTrackingDataService.LOCATION_CONSULT_NOTE_UUID;
+                                    });
+                                    // Only add locations that have the consult note tag
+                                    if (consultNoteTag) {
+                                        $scope.locations.push({
+                                            label: item.name,
+                                            value: item.uuid
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            /*
              loads the system care settings
              */
            $scope.loadingModal = showLoadingModal();
-            return LabTrackingDataService.loadLocations().then(function (respLocations) {
-              if (respLocations.status.code == 200) {
-                $scope.locations = respLocations.data;
-              }
-              return LabTrackingDataService.loadProviders().then(function (respProviders) {
+            // Load locations on controller initialization
+           return  LabTrackingDataService.loadVisitLocations($scope.allEmrLocations, $scope.visitLocations).then(function () {
+                loadLocationsForSession();
+                return LabTrackingDataService.loadProviders().then(function (respProviders) {
                 if (respProviders.status.code == 200) {
                   $scope.providers = respProviders.data;
                 }
@@ -267,7 +315,6 @@ angular.module("labTrackingAddOrderController", [])
                   $scope.loadingModal.dismiss('cancel');
                 });
               });
-
-            });
+           });
         }]);
 

--- a/omod/src/main/webapp/resources/scripts/components/LabTrackingAddOrderController.js
+++ b/omod/src/main/webapp/resources/scripts/components/LabTrackingAddOrderController.js
@@ -9,7 +9,7 @@ angular.module("labTrackingAddOrderController", [])
             $scope.order = new LabTrackingOrder(patientUuid, locationUuid, visitUuid);
             $scope.error = null; // when not null, this message will show on the screen
             $scope.debugInfo = null;  // for debugging
-            $scope.locations = []; // clinical locations in the system
+            $scope.locations = []; // locations to display in the UI to the user
             $scope.allEmrLocations = [];
             $scope.visitLocations = [];
             $scope.providers = []; // the proviers in the system
@@ -293,6 +293,7 @@ angular.module("labTrackingAddOrderController", [])
              */
            $scope.loadingModal = showLoadingModal();
             // Load locations on controller initialization
+            // passes in empty allEmrLocations and visitLocations list to be populated by the loadVisitLocations function
            return  LabTrackingDataService.loadVisitLocations($scope.allEmrLocations, $scope.visitLocations).then(function () {
                 loadLocationsForSession();
                 return LabTrackingDataService.loadProviders().then(function (respProviders) {

--- a/omod/src/main/webapp/resources/scripts/components/LabTrackingDataService.js
+++ b/omod/src/main/webapp/resources/scripts/components/LabTrackingDataService.js
@@ -35,9 +35,11 @@ angular.module("labTrackingDataService", [])
                     ACTIVE_VISIT: "/" + OPENMRS_CONTEXT_PATH + "/ws/rest/emrapi/activevisit",
                     CONCEPT_SEARCH: "/" + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/conceptsearch?q=PROCEDURE_NAME&conceptClasses=" + CONCEPT_CLASS_PROCEDURE_UUID + "&v=custom:(concept:(uuid,display))",
                     DX_SEARCH: "/" + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/conceptsearch?q=DX_NAME&conceptClasses=" + CONCEPT_CLASS_DX_UUID + "&v=custom:(concept:(uuid,display))"
-                }
+                },
             };
 
+            // Expose constants
+            this.LOCATION_CONSULT_NOTE_UUID = LOCATION_CONSULT_NOTE_UUID;
 
             /* gets the print page
              * @param  orderUuid - the order
@@ -100,6 +102,7 @@ angular.module("labTrackingDataService", [])
              */
             this.loadLocations = function () {
                 var url = CONSTANTS.URLS.VIEW_LOCATIONS;
+
                 return $http.get(url).then(function (resp) {
                     if (_self.isOk(resp)) {
                         var data = [];
@@ -134,6 +137,52 @@ angular.module("labTrackingDataService", [])
                     console.error("Error loading locations:", error);
                     return {status: {code: 500, msg: "Error loading locations " + error}, data: []};
                 });
+            };
+
+            /*
+             loads all the Locations and populates the provided arrays. Each location is
+             augmented with a visitLocation property pointing to its nearest ancestor tagged
+             "Visit Location" (or null if it is itself a Visit Location).
+             @param locations - array to populate with all locations
+             @param visitLocations - array to populate with the locations tagged "Visit Location"
+             */
+            this.loadVisitLocations = function (locations, visitLocations) {
+                var deferred = $q.defer();
+                _self.loadAllLocations().then(function (resp) {
+                    if (resp.status.code == 200) {
+                        for (var i = 0; i < resp.data.length; i++) {
+                            locations.push(resp.data[i]);
+                        }
+                        var visitLocs = resp.data.filter(function (location) {
+                            if (location.tags && location.tags.length > 0) {
+                                return location.tags.some(function (tag) {
+                                    return tag.name === "Visit Location";
+                                });
+                            }
+                            return false;
+                        });
+                        for (var j = 0; j < visitLocs.length; j++) {
+                            visitLocations.push(visitLocs[j]);
+                        }
+                        for (var k = 0; k < locations.length; k++) {
+                            var visitLoc = findNearestVisitLocation(locations[k], locations);
+                            // Only add visitLocation if it's different from the location itself
+                            // This prevents a location from referencing itself
+                            if (visitLoc && visitLoc.uuid !== locations[k].uuid) {
+                                locations[k].visitLocation = visitLoc;
+                            } else {
+                                locations[k].visitLocation = null;
+                            }
+                        }
+                        deferred.resolve({locations: locations, visitLocations: visitLocations});
+                    } else {
+                        console.error("Error loading locations:", resp.status.msg);
+                        deferred.reject(resp.status.msg);
+                    }
+                }, function (err) {
+                    deferred.reject(err);
+                });
+                return deferred.promise;
             };
 
             /*
@@ -670,6 +719,10 @@ angular.module("labTrackingDataService", [])
               return _self.session.currentProvider ? _self.session.currentProvider : null;
             }
 
+            this.getSessionLocation = function() {
+                return _self.session.sessionLocation ? _self.session.sessionLocation : null;
+            }
+
             /* helper function to determine if REST response is ok
              * @param {WSResps} res - the response from the server
              * @return true/false
@@ -682,6 +735,55 @@ angular.module("labTrackingDataService", [])
             this.session = SessionInfo.get(); // we use this to get the current provider
 
             //internal functions -----------------------------------------
+
+            /* Recursively finds the first parent location that has a tag with name "Visit Location"
+             * @param location - the location object to search from
+             * @param allLocations - the list of all locations (used to resolve parentLocation by uuid)
+             * @param visitedUuids - optional Set used to prevent infinite loops
+             * @return the parent location with "Visit Location" tag, or null if not found
+             */
+            function findNearestVisitLocation(location, allLocations, visitedUuids) {
+                if (!visitedUuids) {
+                    visitedUuids = new Set();
+                }
+
+                if (!location) {
+                    return null;
+                }
+
+                // Prevent infinite loops; should never happen with correctly designed data
+                if (visitedUuids.has(location.uuid)) {
+                    return null;
+                }
+                visitedUuids.add(location.uuid);
+
+                if (location.tags && location.tags.length > 0) {
+                    var hasVisitLocationTag = location.tags.some(function (tag) {
+                        return tag.name === "Visit Location";
+                    });
+                    if (hasVisitLocationTag) {
+                        return location;
+                    }
+                }
+
+                if (!location.parentLocation || !location.parentLocation.uuid) {
+                    return null;
+                }
+
+                var parentLocation = null;
+                for (var i = 0; i < allLocations.length; i++) {
+                    if (allLocations[i].uuid === location.parentLocation.uuid) {
+                        parentLocation = allLocations[i];
+                        break;
+                    }
+                }
+
+                if (!parentLocation) {
+                    return null;
+                }
+
+                return findNearestVisitLocation(parentLocation, allLocations, visitedUuids);
+            }
 
             /*  gets an obs from a list based on the concept uuid
              * @param list - the list of observations

--- a/omod/src/main/webapp/resources/scripts/components/LabTrackingDataService.js
+++ b/omod/src/main/webapp/resources/scripts/components/LabTrackingDataService.js
@@ -35,7 +35,7 @@ angular.module("labTrackingDataService", [])
                     ACTIVE_VISIT: "/" + OPENMRS_CONTEXT_PATH + "/ws/rest/emrapi/activevisit",
                     CONCEPT_SEARCH: "/" + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/conceptsearch?q=PROCEDURE_NAME&conceptClasses=" + CONCEPT_CLASS_PROCEDURE_UUID + "&v=custom:(concept:(uuid,display))",
                     DX_SEARCH: "/" + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/conceptsearch?q=DX_NAME&conceptClasses=" + CONCEPT_CLASS_DX_UUID + "&v=custom:(concept:(uuid,display))"
-                },
+                }
             };
 
             // Expose constants

--- a/omod/src/main/webapp/resources/scripts/components/LabTrackingViewQueueController.js
+++ b/omod/src/main/webapp/resources/scripts/components/LabTrackingViewQueueController.js
@@ -28,64 +28,6 @@ angular.module("labTrackingViewQueueController", [])
                 $scope.statusCodes.push(status);
             }
 
-            /**
-             * Recursively finds the first parent location that has a tag with name "Visit Location"
-             * @param {Object} location - the location object to search from
-             * @param {Set} visitedUuids - optional set to track visited locations and prevent infinite loops
-             * @return {Object|null} - the parent location with "Visit Location" tag, or null if not found
-             */
-            $scope.findNearestVisitLocation = function(location,  visitedUuids) {
-                // Initialize visited set on first call to prevent infinite loops
-                if (!visitedUuids) {
-                    visitedUuids = new Set();
-                }
-
-                // Base case: location is null or undefined
-                if (!location) {
-                    return null;
-                }
-
-                // Prevent infinite loops by checking if we've already visited this location
-                // This should never happen with correctly designed data
-                if (visitedUuids.has(location.uuid)) {
-                    return null;
-                }
-                visitedUuids.add(location.uuid);
-
-                // Check if current location has "Visit Location" tag
-                if (location.tags && location.tags.length > 0) {
-                    var hasVisitLocationTag = location.tags.some(function(tag) {
-                        return tag.name === "Visit Location";
-                    });
-
-                    if (hasVisitLocationTag) {
-                        return location;
-                    }
-                }
-
-                // If no parent location, we've reached the top without finding a match
-                if (!location.parentLocation || !location.parentLocation.uuid) {
-                    return null;
-                }
-
-                // Find the full parent location object from allLocations array
-                var parentLocation = null;
-                for (var i = 0; i < $scope.locations.length; i++) {
-                    if ($scope.locations[i].uuid === location.parentLocation.uuid) {
-                        parentLocation = $scope.locations[i];
-                        break;
-                    }
-                }
-
-                // If parent not found in the locations array, return null
-                if (!parentLocation) {
-                    return null;
-                }
-
-                // Recursively search the parent location
-                return $scope.findNearestVisitLocation(parentLocation, visitedUuids);
-            };
-
             $scope.getVisitLocation = function(encounterLocation) {
                 if ($scope.locations.length > 0 && encounterLocation && encounterLocation.value) {
                     var location = $scope.locations.find(function(loc) {
@@ -98,38 +40,8 @@ angular.module("labTrackingViewQueueController", [])
                 return null;
             }
 
-            $scope.loadLocations = function() {
-                LabTrackingDataService.loadAllLocations().then(function(resp) {
-                    if (resp.status.code == 200) {
-                        $scope.locations = resp.data;
-                        // Filter locations that have a tag with name "Visit Location"
-                        $scope.visitLocations = resp.data.filter(function(location) {
-                            if (location.tags && location.tags.length > 0) {
-                                return location.tags.some(function(tag) {
-                                    return tag.name === "Visit Location";
-                                });
-                            }
-                            return false;
-                        });
-                        // add a visitLocation property to each location so we can map each location to it's visit location
-                        for (var i = 0; i < $scope.locations.length; i++) {
-                            var visitLoc = $scope.findNearestVisitLocation($scope.locations[i]);
-                            // Only add visitLocation if it's different from the location itself
-                            // This prevents a location from referencing itself
-                            if (visitLoc && visitLoc.uuid !== $scope.locations[i].uuid) {
-                                $scope.locations[i].visitLocation = visitLoc;
-                            } else {
-                                $scope.locations[i].visitLocation = null;
-                            }
-                        }
-                    } else {
-                        console.error("Error loading locations:", resp.status.msg);
-                    }
-                });
-            };
-
             // Load locations on controller initialization
-            $scope.loadLocations();
+            LabTrackingDataService.loadVisitLocations($scope.locations, $scope.visitLocations);
 
             var fromDate = new Date();
             fromDate.setDate(fromDate.getDate() - LabTrackingDataService.CONSTANTS.MONITOR_PAGE_DAYS_BACK);


### PR DESCRIPTION
@mogoodrich , I have moved the code I used in the view controller to be used by the add order page too. Here is how the pathology order form looks now with the locations filtered to only the user's login visit locations:

<img width="1246" height="839" alt="Screenshot 2026-05-15 at 4 19 00 PM" src="https://github.com/user-attachments/assets/32896a47-5b76-4055-b0fd-26af17aa704e" />
